### PR TITLE
Update cabal file to support GHC 8

### DIFF
--- a/hlCompiler.cabal
+++ b/hlCompiler.cabal
@@ -24,7 +24,7 @@ executable hlCompiler
                      , Demo.EvenOdd
                      , Demo.PNCalc
   -- other-extensions:
-  build-depends:       base >=4.8 && <4.9
+  build-depends:       base >=4.8 && < 4.10
                      , mtl >= 2.2 && < 2.3
                      , containers >= 0.5.6 && < 0.5.8
                      , pretty >= 1.1 && < 1.2
@@ -52,7 +52,7 @@ test-suite test
                      , Util
                      , Demo.EvenOdd
                      , Demo.PNCalc
-  build-depends:    base >=4.8 && <4.9
+  build-depends:    base >=4.8 && < 4.10
                   , mtl >= 2.2 && < 2.3
                   , containers >= 0.5.6 && < 0.5.8
                   , pretty >= 1.1 && < 1.2


### PR DESCRIPTION
While setting up GHC 8 on my machine, I figured I'd see if this compiles with it. Had to bump the base upper bound, but the test suite passes just fine.
